### PR TITLE
Add a button to cycle through siblings in item editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ F14 = Edit parent
 F15 = Add child  
 F16 = Add sibling  
 F17 = Take photo
+F18 = Next sibling (when editing an existing item)

--- a/client/src/components/ItemEditor.vue
+++ b/client/src/components/ItemEditor.vue
@@ -78,6 +78,7 @@
       </div>
       <div class="buttons">
         <button @click="uploadItem()">Save</button>
+        <button v-if="item.id" @click="navSibling()">Next sibling</button>
         <button @click="navRight()">Add sibling</button>
         <button @click="navDown()">Add child</button>
         <button @click="navUp()">Edit parent</button>
@@ -141,6 +142,9 @@ export default defineComponent({
     up(details: ItemDetails) {
       return !!details;
     },
+    next(details: ItemDetails) {
+      return !!details;
+    },
   },
   methods: {
     load() {
@@ -163,6 +167,9 @@ export default defineComponent({
     },
     navUp() {
       this.$emit('up', this.item);
+    },
+    navSibling() {
+      this.$emit('next', this.item);
     },
     focusTitle() {
       const titleInput = this.$refs.title as HTMLInputElement;
@@ -214,6 +221,9 @@ export default defineComponent({
           break;
         case 'F17':
           this.photoShortcut++;
+          break;
+        case 'F18':
+          this.navSibling();
           break;
       }
     },
@@ -334,9 +344,11 @@ div.rhs {
     justify-content: space-between;
 
     button {
-      font-size: 150%;
+      font-size: 110%;
       margin: 0.2rem 0;
       padding: 0.2em 0.5em;
+      flex-shrink: 1;
+      white-space: nowrap;
     }
   }
 

--- a/client/src/views/EditItem.vue
+++ b/client/src/views/EditItem.vue
@@ -1,9 +1,9 @@
 <template>
   <item-editor :id="$route.params.id" :key="$route.params.id + ' ' + submitted"
-               @upload="update" @right="navRight" @down="navDown" @up="navUp"/>
+               @upload="update" @right="navRight" @down="navDown" @up="navUp" @next="navNext"/>
   <section>
     <h2>Children</h2>
-    <item-list :parent="parseInt($route.params.id.toString())"/>
+    <item-list :parent="parseInt($route.params.id.toString())" :key="$route.params.id"/>
   </section>
 </template>
 
@@ -61,6 +61,12 @@ export default defineComponent({
             .then(() => this.$router.push(`/item/${item.parent}`))
             .catch(this.toast.error);
       }
+    },
+    navNext(item: ItemDetails) {
+      fetch(`http://localhost:5000/sibling/${item.id}`)
+      .then((response) => response.json())
+      .then((json) => this.$router.push(`/item/${json.id}`))
+      .catch(this.toast.error);
     },
   },
 });


### PR DESCRIPTION
Fixes: #47

Add a key to the children list so it updates automatically when navigating.

Add keyboard shortcut F18 to cycle through siblings.